### PR TITLE
ディレクトリ作成の箇所で、非同期の関数を使っていたために次のファイル書き込みでエラーが発生する可能性がある問題を解決。

### DIFF
--- a/utility.js
+++ b/utility.js
@@ -43,9 +43,7 @@ export const genImageUrlFromBytes = async (data, req) => {
     const fileName = genFileNameFromDatetime('jpg');
     const path = 'public/image/' + fileName;
     
-    fs.mkdir('public/image', {recursive: true}, (err) => {
-        console.error('ディレクトリの作成に失敗: ', err);
-    });
+    fs.mkdirSync('public/image', {recursive: true});
     fs.writeFileSync(path, data);
 
     const url = 'https' + '://' + req.get( 'host' ) + '/static/image/' + fileName;


### PR DESCRIPTION
ディレクトリの作成を非同期で行っていたが、このままだと次のファイル作成の時点ではまだディレクトリが作成されていないのでエラーになる可能性がある。
そのため、fs.mkdirを、同期関数であるfs.mkdirSyncに変更した。