### PR TITLE
utility.jsのファイル分割

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -7,7 +7,7 @@ import 'dotenv/config'; // このモジュールで.envから環境変数を設�
 // ファイルの読み込み
 import { index } from '../linebot/bot.js';
 
-import * as utility from '../utility.js';
+import { utility } from '../utility.js';
 
 
 // 初期処理
@@ -31,8 +31,8 @@ app.post('/webhook', middleware({
 
 app.post('/intercom/notice', express.json(), (req, res) => {
     // IoTから送られてきたデータを整理して、LINEのテキストとしてPUSHメッセージを送る
-    const message = utility.makeTextMessage(`${req.body.datetime}\n訪問者が来ました`);
-    utility.getUserIdFromDeviceID(req.body.id).then((userId) => {
+    const message = utility.makeMessage.text(`${req.body.datetime}\n訪問者が来ました`);
+    utility.database.getUserIdFromDeviceID(req.body.id).then((userId) => {
         client.pushMessage(userId, message);
     })
     res.send("ok");
@@ -41,8 +41,8 @@ app.post('/intercom/notice', express.json(), (req, res) => {
 
 app.post('/intercom/text',express.json(),(req, res) => {
     // IoTから送られてきた音声のテキストをLINEのテキストとしてPUSHメッセージを送る
-    const message = utility.makeTextMessage(`訪問者からのメッセージ:\n${req.body.text}`);
-    utility.getUserIdFromDeviceID(req.body.id).then((userId) => {
+    const message = utility.makeMessage.text(`訪問者からのメッセージ:\n${req.body.text}`);
+    utility.database.getUserIdFromDeviceID(req.body.id).then((userId) => {
         client.pushMessage(userId, message);
     })
     res.send("ok");
@@ -51,10 +51,10 @@ app.post('/intercom/text',express.json(),(req, res) => {
 // 訪問者の写真が送られてくる
 app.post('/intercom/image', express.json({limit: '10mb'}), (req, res) => {
     const data = Buffer.from(req.body.data, 'base64');
-    utility.genImageUrlFromBytes(data, req)
+    utility.func.genImageUrlFromBytes(data, req)
         .then((imageUrl) => {
-            const message = utility.makeVisitorsImageMessage(imageUrl);
-            utility.getUserIdFromDeviceID(req.body.id).then((userId) => {
+            const message = utility.makeMessage.visitorsImage(imageUrl);
+            utility.database.getUserIdFromDeviceID(req.body.id).then((userId) => {
                 client.pushMessage(userId, message);
             })
         });

--- a/linebot/event/message/text.js
+++ b/linebot/event/message/text.js
@@ -1,4 +1,4 @@
-import * as utility from "../../../utility.js"
+import { utility } from "../../../utility.js"
 
 export const textEvent = async (event, client) => {
     let message;
@@ -6,18 +6,18 @@ export const textEvent = async (event, client) => {
     console.log('テキストメッセージを受信: ' + event.message.text);
     //メッセージのテキストごとに条件分岐
     if(event.message.text.startsWith('deviceid=')) {
-        utility.addDeviceID(event.userId, event.message.text.substr(9));
+        utility.database.addDeviceID(event.userId, event.message.text.substr(9));
         return;
     }
 
     if (event.message.text.startsWith('removedeviceid=')) {
-        utility.removeDeviceID(event.message.text.substr(15));
+        utility.database.removeDeviceID(event.message.text.substr(15));
         return;
     }
     
     switch (event.message.text) {
         default: {
-            message = utility.makeTextMessage('このメッセージの返信には対応していません...');
+            message = utility.makeMessage.text('このメッセージの返信には対応していません...');
             break;
         }
     }

--- a/utility.js
+++ b/utility.js
@@ -1,83 +1,9 @@
-import * as fs from 'fs';
-import sqlite3 from 'sqlite3';
+import * as makeMessage from './utility/makeMessage.js';
+import * as database from './utility/database.js';
+import * as func from './utility/func.js';
 
-const DATABASE_PATH = 'database.sqlite3';
-
-export const makeTextMessage = (text) => {
-    return {
-        type: "text",
-        text: text
-    }
-}
-
-// 訪問者の写真ビュー用のメッセージを生成する
-export const makeVisitorsImageMessage = (imageUrl) => {
-    return {
-        type: 'flex',
-        altText: 'This is a Flex Message',
-        contents: {
-            type: "bubble",
-            hero: {
-                type: "image",
-                url: imageUrl,
-                size: "full",
-                aspectMode: "fit"
-            },
-            body: {
-                type: "box",
-                layout: "vertical",
-                contents: []
-            }
-        }
-    }
-}
-
-// 日時からファイル名を生成する
-export const genFileNameFromDatetime = (ext, date=Date.now()) => {
-    const dt = new Date(date);
-    return dt.toISOString().replace(/[\-T:\.]/g, '_').replace('Z', '') + '.' + ext;
-}
-
-// 画像データを保存して画像へのURLをリターンする（非同期）
-export const genImageUrlFromBytes = async (data, req) => {
-    const fileName = genFileNameFromDatetime('jpg');
-    const path = 'public/image/' + fileName;
-    
-    fs.mkdirSync('public/image', {recursive: true});
-    fs.writeFileSync(path, data);
-
-    const url = 'https' + '://' + req.get( 'host' ) + '/static/image/' + fileName;
-    return url;
-}
-
-export const initDatabase = () => {
-    const db = new sqlite3.Database(DATABASE_PATH);
-    const sqlQuery = fs.readFileSync('./schema.sql');
-    db.run(sqlQuery.toString(), () => {
-        db.close();
-    });
-}
-
-export const addDeviceID = (userId, deviceId) => {
-    const db = new sqlite3.Database(DATABASE_PATH);
-    db.run("insert into users values(?,?)", [userId, deviceId], () => {
-        db.close();
-    });
-}
-
-export const getUserIdFromDeviceID = (deviceId) => {
-    return new Promise((resolve, reject) => {
-        const db = new sqlite3.Database(DATABASE_PATH);
-        db.get("select * from users where device_id = ?", deviceId, (err, row) => {
-            resolve(row["user_id"]);
-            db.close();
-        });
-    });
-}
-
-export const removeDeviceID = (deviceId) => {
-    const db = new sqlite3.Database(DATABASE_PATH);
-    db.run("delete from users where device_id = ?", [deviceId], () => {
-        db.close();
-    });
-}
+export const utility = {
+    makeMessage: makeMessage,
+    database: database,
+    func: func
+};

--- a/utility/database.js
+++ b/utility/database.js
@@ -1,0 +1,36 @@
+import sqlite3 from 'sqlite3';
+
+const DATABASE_PATH = 'database.sqlite3';
+
+
+export const initDatabase = () => {
+    const db = new sqlite3.Database(DATABASE_PATH);
+    const sqlQuery = fs.readFileSync('./schema.sql');
+    db.run(sqlQuery.toString(), () => {
+        db.close();
+    });
+}
+
+export const addDeviceID = (userId, deviceId) => {
+    const db = new sqlite3.Database(DATABASE_PATH);
+    db.run("insert into users values(?,?)", [userId, deviceId], () => {
+        db.close();
+    });
+}
+
+export const getUserIdFromDeviceID = (deviceId) => {
+    return new Promise((resolve, reject) => {
+        const db = new sqlite3.Database(DATABASE_PATH);
+        db.get("select * from users where device_id = ?", deviceId, (err, row) => {
+            resolve(row["user_id"]);
+            db.close();
+        });
+    });
+}
+
+export const removeDeviceID = (deviceId) => {
+    const db = new sqlite3.Database(DATABASE_PATH);
+    db.run("delete from users where device_id = ?", [deviceId], () => {
+        db.close();
+    });
+}

--- a/utility/func.js
+++ b/utility/func.js
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+
+// 日時からファイル名を生成する
+export const genFileNameFromDatetime = (ext, date=Date.now()) => {
+    const dt = new Date(date);
+    return dt.toISOString().replace(/[\-T:\.]/g, '_').replace('Z', '') + '.' + ext;
+}
+
+// 画像データを保存して画像へのURLをリターンする（非同期）
+export const genImageUrlFromBytes = async (data, req) => {
+    const fileName = genFileNameFromDatetime('jpg');
+    const path = 'public/image/' + fileName;
+    
+    fs.mkdirSync('public/image', {recursive: true});
+    fs.writeFileSync(path, data);
+
+    const url = 'https' + '://' + req.get( 'host' ) + '/static/image/' + fileName;
+    return url;
+}

--- a/utility/makeMessage.js
+++ b/utility/makeMessage.js
@@ -1,0 +1,28 @@
+export const text = (text) => {
+    return {
+        type: "text",
+        text: text
+    }
+}
+
+// 訪問者の写真ビュー用のメッセージを生成する
+export const visitorsImage = (imageUrl) => {
+    return {
+        type: 'flex',
+        altText: 'This is a Flex Message',
+        contents: {
+            type: "bubble",
+            hero: {
+                type: "image",
+                url: imageUrl,
+                size: "full",
+                aspectMode: "fit"
+            },
+            body: {
+                type: "box",
+                layout: "vertical",
+                contents: []
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 変更内容
utility.jsをジャンルごとにファイルを分割しました。
それに伴い、関数の使用方法とimport方法が変更になります。
ジャンルごとのファイルはutilityディレクトリに配置し、utility.jsからimportしています。

## utility.jsを以下の3つジャンルにファイルを分割
- lineメッセージの生成 (utility/makeMessage.js)
- データベースの操作 (utility/database.js)
- その他の関数 (utility/func.js)

## 変更後の関数の使用方法
- utility.makeMessage.関数名
- utility.database.関数名
- utilty.func.関数名

## import方法
- import { utility } from 'utility.jsへの相対パス'